### PR TITLE
Added a battery status script and prevented ratpoison mode key and default mode key from both being Super (mod4)

### DIFF
--- a/i38.sh
+++ b/i38.sh
@@ -287,6 +287,9 @@ bindsym \$mod+F1 exec --no-startup-id sgtk-menu -f
 # Desktop icons
 bindsym \$mod+Control+d exec --no-startup-id yad --icons --compact --no-buttons --title="Desktop" --close-on-unfocus --read-dir=${HOME}/Desktop
 
+#Check battery status
+bindsym \$mod+Control+b exec --no-startup-id ${i3Path}/scripts/battery_status.sh
+
 # change focus
 # alt+tab and shift tab
 bindsym Mod1+Shift+Tab focus left

--- a/i38.sh
+++ b/i38.sh
@@ -145,12 +145,19 @@ while getopts "${args}" i ; do
 done
 
 # Configuration questions
+#Prevent setting ratpoison mode key to the same as default mode key
+while [ "$escapeKey == "$mod" ]
+do
 escapeKey="$(menulist "Ratpoison mode key:" Control+t Control+z Control+Escape Alt+Escape Control+Space Super)"
 escapeKey="${escapeKey//Alt/Mod1}"
 escapeKey="${escapeKey//Super/Mod4}"
 mod="$(menulist "I3 mod key, for top level bindings:" Alt Control Super)"
 mod="${mod//Alt/Mod1}"
 mod="${mod//Super/Mod4}"
+if [ ""$escapeKey" == "$mod" ]; then
+echo "Sorry, these cannot be the same key."
+fi
+done
 # Volume jump
 volumeJump=$(rangebox "How much should pressing the volume keys change the volume?" 1 15 5)
 # Web browser

--- a/i38.sh
+++ b/i38.sh
@@ -154,7 +154,7 @@ escapeKey="${escapeKey//Super/Mod4}"
 mod="$(menulist "I3 mod key, for top level bindings:" Alt Control Super)"
 mod="${mod//Alt/Mod1}"
 mod="${mod//Super/Mod4}"
-if [ ""$escapeKey" == "$mod" ]; then
+if [ "$escapeKey" == "$mod" ]; then
 echo "Sorry, these cannot be the same key."
 fi
 done

--- a/i38.sh
+++ b/i38.sh
@@ -9,7 +9,7 @@ i3Path="${XDG_CONFIG_HOME:-$HOME/.config}/i3"
 export DIALOGOPTS='--no-lines --visit-items'
 
 # Check to make sure minimum requirements are installed.
-for i in dialog grun sgtk-menu yad ; do
+for i in dialog grun sgtk-menu yad zenity ; do
     if ! command -v "$i" &> /dev/null ; then
         missing+=("$i")
     fi

--- a/i38.sh
+++ b/i38.sh
@@ -146,7 +146,7 @@ done
 
 # Configuration questions
 #Prevent setting ratpoison mode key to the same as default mode key
-while [ "$escapeKey == "$mod" ]
+while [ "$escapeKey" == "$mod" ]
 do
 escapeKey="$(menulist "Ratpoison mode key:" Control+t Control+z Control+Escape Alt+Escape Control+Space Super)"
 escapeKey="${escapeKey//Alt/Mod1}"

--- a/scripts/battery_status.sh
+++ b/scripts/battery_status.sh
@@ -1,0 +1,10 @@
+#!/bin/env bash
+#Get battery status
+cd /sys/class/power_supply
+for f in `ls`; do
+if [ -e $f"/capacity" ]; then
+export stat=`cat $f"/status"`
+export cap=`cat $f"/capacity"`
+echo battery $f": "$stat", "$cap"%"
+fi
+done|zenity --text-info --filename=/dev/stdin --title "Power Status"


### PR DESCRIPTION
Added a battery status script to get battery percentage and charging state

Updated i38.sh to add the dependency check for zenity, required for the battery status script, and added a key binding (mod+Control+b) to execute battery status script.